### PR TITLE
Fix Typescript Svelte Bug

### DIFF
--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -68,12 +68,13 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^5.2.1",
-    "typescript": "~3.8",
+    "typescript": "^4.2.4",
     "webpack": "^5.20.1",
     "webpack-cli": "^4.4.0",
     "webpack-dev-server": "^3.11.2",
     "svelte": "^3.0.0",
-    "svelte-loader": "2.13.3"
+    "svelte-loader": "2.13.3",
+    "svelte-preprocess": "^4.7.0"
   },
   "jupyterlab": {
     "extension": "lib/plugin"

--- a/{{cookiecutter.github_project_name}}/src/App.svelte
+++ b/{{cookiecutter.github_project_name}}/src/App.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   export let model;
 
   // Creates a Svelte store (https://svelte.dev/tutorial/writable-stores) that syncs with the named Traitlet in widget.ts and example.py.

--- a/{{cookiecutter.github_project_name}}/tsconfig.json
+++ b/{{cookiecutter.github_project_name}}/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/{{cookiecutter.github_project_name}}/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/webpack.config.js
@@ -2,6 +2,9 @@ const path = require('path');
 const version = require('./package.json').version;
 const SveltePreprocess = require('svelte-preprocess');
 
+// Mode needs to be set to prevent warning
+const mode = 'development';
+
 // Custom webpack rules
 const rules = [
   {
@@ -31,6 +34,7 @@ const resolve = {
 module.exports = [
   /** Lib - compile Typescript and Svelte files. */
   {
+    mode: mode,
     entry: {
       plugin: './src/plugin.ts',
     },
@@ -48,6 +52,7 @@ module.exports = [
   },
   /** Mock - server to test changes w/o building Jupyter */
   {
+    mode: mode,
     entry: {
       bundle: ['./src/mock.ts'],
     },
@@ -71,6 +76,7 @@ module.exports = [
    * the notebook.
    */
   {
+    mode: mode,
     entry: './src/extension.ts',
     output: {
       filename: 'index.js',
@@ -101,6 +107,7 @@ module.exports = [
    * the custom widget embedder.
    */
   {
+    mode: mode,
     entry: './src/index.ts',
     output: {
       filename: 'index.js',
@@ -126,6 +133,7 @@ module.exports = [
    * This bundle is used to embed widgets in the package documentation.
    */
   {
+    mode: mode,
     entry: './src/index.ts',
     output: {
       filename: 'embed-bundle.js',

--- a/{{cookiecutter.github_project_name}}/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/webpack.config.js
@@ -1,11 +1,15 @@
 const path = require('path');
 const version = require('./package.json').version;
+const SveltePreprocess = require('svelte-preprocess');
 
 // Custom webpack rules
 const rules = [
   {
     test: /\.svelte$/,
     loader: 'svelte-loader',
+    options: {
+      preprocess: SveltePreprocess(),
+    }
   },
   { test: /\.ts$/, loader: 'ts-loader' },
   { test: /\.js$/, loader: 'source-map-loader' },


### PR DESCRIPTION
I included the preprocessor to fix a bug where writing ts inside of svelte `<script>` tags was not possible. For this to work, I needed to remove `"module": "commonjs"` from `.tsconfig.json`.

Also removed a compilation warning by adding a mode variable.