### PR TITLE
Allow setting initial widget values from python

### DIFF
--- a/{{cookiecutter.github_project_name}}/src/mock.ts
+++ b/{{cookiecutter.github_project_name}}/src/mock.ts
@@ -4,6 +4,7 @@ import App from './App.svelte';
 class MockModel {
   set() {}
   undo() {}
+  get(name: string) {}
   on(variableName: string, callback: () => void, context: any) {}
   save_changes() {}
 }

--- a/{{cookiecutter.github_project_name}}/src/stores.ts
+++ b/{{cookiecutter.github_project_name}}/src/stores.ts
@@ -3,7 +3,10 @@ import { writable } from 'svelte/store';
 
 export function createValue(model: any, name_: string, value_: any) {
   const name: string = name_;
-  const curVal: Writable<any> = writable(value_);
+  const modelValue = model.get(name);
+  const curVal: Writable<any> = writable(
+    modelValue === undefined ? value_ : modelValue
+  );
 
   model.on('change:' + name, () => curVal.set(model.get(name)), null);
 


### PR DESCRIPTION
This small change allows widget users to set its values when initializing the widget in a notebook.

So for example

```
w = ExampleWidget(value=20)
```

will start counting from 20 instead of 0.

Current version only allows setting the value like this:

```
w = ExampleWidget()
w.value = 20
```

I made this change for a widget based on this cookiecutter. Maybe it'll save others some time if they want to have this initialization style.
Thanks for sharing the template! =)